### PR TITLE
✨ OperationIds for Controller Methods

### DIFF
--- a/services/results-server/src/main/java/org/lisasp/results/CompetitionRestService.java
+++ b/services/results-server/src/main/java/org/lisasp/results/CompetitionRestService.java
@@ -12,6 +12,8 @@ import org.lisasp.results.model.CompetitionService;
 import org.lisasp.competition.api.exception.NotFoundException;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+
 @Slf4j
 @RestController
 @RequestMapping("api")
@@ -21,22 +23,26 @@ public class CompetitionRestService {
     private final CompetitionService service;
 
     @PostMapping("/competition")
+    @Operation(operationId = "createCompetition")
     public CompetitionCreated create(@RequestBody CreateCompetition createCompetition) {
         log.info("Import from JAuswertung for {}", createCompetition.name());
         return service.execute(createCompetition);
     }
 
     @GetMapping("/competition/{id}")
+    @Operation(operationId = "getCompetitionById")
     public CompetitionDto get(@PathVariable String id) throws NotFoundException {
         return service.findCompetition(id);
     }
 
     @GetMapping("/competition")
+    @Operation(operationId = "findAllCompetitions")
     public CompetitionDto[] findAll() {
         return service.findCompetitions();
     }
 
     @GetMapping("/competition/{id}/time")
+    @Operation(operationId = "findAllTimesByCompetitionId")
     public TimeDto[] findAll(@PathVariable String id) {
         return switch (id) {
             case "1" -> new TimeDto[]{

--- a/services/results-server/src/main/java/org/lisasp/results/EntryRestService.java
+++ b/services/results-server/src/main/java/org/lisasp/results/EntryRestService.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+
 @RestController
 @RequestMapping("api")
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class EntryRestService {
 
 
     @GetMapping("/event/{eventId}/entry")
+    @Operation(operationId = "findAllEntriesByEventId")
     public EntryDto[] findAll(@PathVariable String eventId) {
         return service.findEntries(eventId);
     }

--- a/services/results-server/src/main/java/org/lisasp/results/EventRestService.java
+++ b/services/results-server/src/main/java/org/lisasp/results/EventRestService.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+
 @RestController
 @RequestMapping("api")
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ public class EventRestService {
 
 
     @GetMapping("/competition/{competitionId}/event")
+    @Operation(operationId = "findAllEventsByCompetitionId")
     public EventDto[] findAll(@PathVariable String competitionId) {
         return service.findEvents(competitionId);
     }


### PR DESCRIPTION
@dennisfabri Was hälst du davon? Ich hätte in der OpenAPI definition JSON gerne korrekte `operationIds`. Dann kann ich im Front-End sehr viel besser damit arbeiten. Entweder müssten die Controller-Methoden entsprechend heißen, oder wir benutzen die Annotation. Soll nur ein Diskussionsanstoß sein.